### PR TITLE
make dist for Windows, Linux and MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,15 @@
 # are available under the MIT License.
 
 
+.PHONY: help code-check coverage dist run test
+
+
 help:
 	@echo Valid targets are:
 	@echo help - Prints this help message
 	@echo code-check - Runs pycodestyle on all python code in the project
 	@echo coverage - Use pytest to run all tests and report on test coverage
+	@echo dist - Creates a single executable package for the local OS
 	@echo run - Runs coverter application
 	@echo test - Use pytest to run all tests
 
@@ -31,6 +35,7 @@ ifeq ($(OS),Windows_NT)
   ACTIVATE = $(VENV)\Scripts\activate && set PYTHONPATH=.
   RMDIR_CMD := rmdir /s /q
   virtualenv = $(shell where virtualenv.exe)
+  SEPARATOR = ;
 else
   CP = cp
   GIT_HOOKS_TARGET = .git/hooks/pre-commit
@@ -40,7 +45,10 @@ else
   ACTIVATE = export PYTHONPATH=.; . $(VENV)/bin/activate
   RMDIR_CMD = rm -rf
   virtualenv = $(shell which virtualenv)
+  SEPARATOR = :
 endif
+
+DATA_DIR = "converter/Calibration Tables$(SEPARATOR)Calibration Tables"
 
 
 $(GIT_HOOKS_TARGET): $(GIT_HOOKS_SOURCE)
@@ -77,7 +85,8 @@ coverage: $(VENV)
 	@$(ACTIVATE) && pytest --cov=converter --cov-report=term \
 	  --cov-report=html
 
-package: $(VENV)
+dist: $(VENV)
+	@-$(RMDIR_CMD) dist
 	@$(ACTIVATE) && pyinstaller converter/main.py \
-	  --add-data "converter/Calibration Tables:Calibration Tables" \
+	  --add-data $(DATA_DIR) \
 	  --onefile --noconsole

--- a/Makefile
+++ b/Makefile
@@ -74,4 +74,10 @@ test: $(VENV)
 
 
 coverage: $(VENV)
-	@$(ACTIVATE) && pytest --cov=converter --cov-report=term --cov-report=html
+	@$(ACTIVATE) && pytest --cov=converter --cov-report=term \
+	  --cov-report=html
+
+package: $(VENV)
+	@$(ACTIVATE) && pyinstaller converter/main.py \
+	  --add-data "converter/Calibration Tables:Calibration Tables" \
+	  --onefile --noconsole

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ flake8
 mock
 pytest
 pytest-cov
+pyinstaller
+
 numpy
 h5py
 PyQt5==5.9.2


### PR DESCRIPTION
To test:
- On either a Windows, Linux, or MacOS* system run `make dist`
- The result should be a single file under the `dist` directory (called `main.exe` or just `main` respectively)
- Note that the calibration file got loaded
- Load a .lid file to make sure that works.
- Profit.

* Note: For the MacOS build to work you have to be running python 3.6 and python needs to be built with the --enable-framework flag.